### PR TITLE
fix missed S in iron-icons dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "iron-fit-behavior": "PolymerElements/iron-fit-behavior#^0.9.0",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^0.9.0",
     "iron-icon": "PolymerElements/iron-icon#^0.9.0",
-    "iron-icons": "PolymerElements/iron-icon#^0.9.0",
+    "iron-icons": "PolymerElements/iron-icons#^0.9.0",
     "iron-iconset": "PolymerElements/iron-iconset#^0.9.0",
     "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^0.9.0",
     "iron-image": "PolymerElements/iron-image#^0.9.0",


### PR DESCRIPTION
It seems that the "iron-icons" dependency missed "s" letter and point to "iron-icon"
