### PR TITLE
Cleanup description in `bower.json`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "iron-elements",
   "version": "1.0.1",
-  "description": "Iron elements are a set of visual and non-visual utility elements. They include elements for working with layout, user input, selection, and scaffolding apps.",
+  "description": "A set of visual and non-visual utility elements. Includes elements for working with layout, user input, selection, and scaffolding apps",
   "keywords": [
     "web-components",
     "polymer",


### PR DESCRIPTION
Trims the description in the `bower.json` file to a valid length (it's 135 now).

Fix #10
